### PR TITLE
Update package.json - support for commonJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,12 @@
     "build-esm": "esbuild --bundle --format=esm --target=es2018 --platform=browser --minify --sourcemap --outfile=./dist/face-api.esm.js --log-level=error --tsconfig=./tsconfig.json --external:util --external:string_decoder --external:fs src/index.ts",
     "build-esm-nobundle": "esbuild --bundle --format=esm --target=es2018 --platform=browser --sourcemap --outfile=./dist/face-api.esm.nobundle.js --log-level=error --tsconfig=./tsconfig.json --external:@tensorflow --external:util --external:string_decoder --external:fs --global-name=faceapi src/index.ts",
     "build-iife": "esbuild --bundle --format=iife --target=es2018 --platform=browser --minify --sourcemap --outfile=./dist/face-api.js --log-level=error --tsconfig=./tsconfig.json --external:util --external:string_decoder --external:fs --global-name=faceapi src/index.ts",
-    "build-node": "esbuild --bundle --format=cjs --target=es2018 --platform=node --minify --sourcemap --outfile=./dist/face-api.node.js --log-level=error --tsconfig=./tsconfig.json src/index.ts",
-    "build-node-nobundle": "esbuild --bundle --format=cjs --target=es2018 --platform=node --sourcemap --outfile=./dist/face-api.node.nobundle.js --external:@tensorflow --log-level=error --tsconfig=./tsconfig.json src/index.ts",
     "build": "rimraf build/* dist/* && tsc && npm run build-iife && npm run build-esm && npm run build-esm-nobundle && npm run build-node && npm run build-node-nobundle && ls -l dist/"
+  },
+  "type": "commonjs",
+  "scripts": {
+    "build-node": "esbuild --bundle --format=cjs --target=es2018 --platform=node --minify --sourcemap --outfile=./dist/face-api.node.js --log-level=error --tsconfig=./tsconfig.json src/index.ts",
+    "build-node-nobundle": "esbuild --bundle --format=cjs --target=es2018 --platform=node --sourcemap --outfile=./dist/face-api.node.nobundle.js --external:@tensorflow --log-level=error --tsconfig=./tsconfig.json src/index.ts"
   },
   "keywords": [
     "tensorflow",


### PR DESCRIPTION
nodeJS 12 added forced support for ES
error is thrown by the .js extension handler in the CJS loader for Node.js

fix - use type": "commonjs", for building the common node stuff