### PR TITLE
fix: return empty descriptor for zero-sized faces

### DIFF
--- a/src/faceRecognitionNet/FaceRecognitionNet.ts
+++ b/src/faceRecognitionNet/FaceRecognitionNet.ts
@@ -61,6 +61,10 @@ export class FaceRecognitionNet extends NeuralNetwork<NetParams> {
   }
 
   public async computeFaceDescriptor(input: TNetInput): Promise<Float32Array|Float32Array[]> {
+    // When faces have a detected dimension of 0, tensorflow will crash the whole process.
+    // Sidestep this by returning an empty descriptor instead.
+    if (input.shape.some(dimension => dimension <= 0) return new Float32Array(128);
+    
     const netInput = await toNetInput(input);
 
     const faceDescriptorTensors = tf.tidy(


### PR DESCRIPTION
thanks for the great project for tf2 😃 ! 

I had this fix on face-api.js using [patch-package](https://www.npmjs.com/package/patch-package), but since the distributed versions here are minified it was rather hard to do it and figured I'd upstream :)

I'm also open to throwing instead and then just catching in ComputeFaceDescriptorsTasks.ts instead? But either way being able to essentially skip 0-dimension descriptor computation is the goal here.