### PR TITLE
Add node-cpu build for non supported systems of libtensorflow

### DIFF
--- a/server/build.js
+++ b/server/build.js
@@ -88,6 +88,24 @@ const targets = {
       external: ['@tensorflow'],
     },
   },
+  nodeCPU: {
+    tfjs: {
+      platform: 'node',
+      format: 'cjs',
+      metafile: 'dist/tfjs.esm.json',
+      entryPoints: ['src/tfjs/tf-node-cpu.ts'],
+      outfile: 'dist/tfjs.esm.js',
+      external: ['@tensorflow'],
+    },
+    node: {
+      platform: 'node',
+      format: 'cjs',
+      metafile: 'dist/face-api.node-cpu.json',
+      entryPoints: ['src/index.ts'],
+      outfile: 'dist/face-api.node-cpu.js',
+      external: ['@tensorflow'],
+    },
+  },
   browserNoBundle: {
     tfjs: {
       platform: 'browser',

--- a/src/tfjs/tf-node-cpu.ts
+++ b/src/tfjs/tf-node-cpu.ts
@@ -1,0 +1,6 @@
+/* eslint-disable import/no-extraneous-dependencies */
+/* eslint-disable node/no-unpublished-import */
+
+
+export * from '@tensorflow/tfjs';
+


### PR DESCRIPTION
Thank you for providing an updated version of face-api.js! Awesome work.

This PR is to support systems where @tensorflow/tfjs-node is not available due unsupported system of libtensorflow like an Raspberry Pi with Ubuntu or older CPU. These systems can than import @vladmandic/face-api/dist/face-api.node-cpu and set the backend to cpu or wasm.