### PR TITLE
fix face expression detection

### DIFF
--- a/src/dom/bufferToVideo.ts
+++ b/src/dom/bufferToVideo.ts
@@ -7,10 +7,9 @@ export function bufferToVideo(buf: Blob): Promise<HTMLVideoElement> {
     const video = env.getEnv().createVideoElement();
     video.oncanplay = () => resolve(video);
     video.onerror = reject;
-    // video.type = buf.type;
     video.playsInline = true;
-    video.autoplay = true;
     video.muted = true;
     video.src = URL.createObjectURL(buf);
+    video.play();
   });
 }


### PR DESCRIPTION
i just found another bug when using the face expression detection - every frame returned "neutral 0.99", so i need to change `video.autoplay = true` to `video.play()` - i don't know why it doesn't work with autoplay, but the code for the webcam also uses `play()`, so i think it is save to use it here as well, i already tested locally and then i got other expressions as well :)
